### PR TITLE
Stop truncating the commit hash.

### DIFF
--- a/homu/main.py
+++ b/homu/main.py
@@ -547,12 +547,12 @@ def parse_commands(body, username, repo_cfg, state, my_username, db, states,
                 if cur_sha:
                     msg = '`{}` is not a valid commit SHA.'.format(cur_sha)
                     state.add_comment(
-                        ':scream_cat: {} Please try again with `{:.7}`.'
+                        ':scream_cat: {} Please try again with `{}`.'
                         .format(msg, state.head_sha)
                     )
                 else:
                     state.add_comment(
-                        ':pushpin: Commit {:.7} has been approved by `{}`\n\n<!-- @{} r={} {} -->'  # noqa
+                        ':pushpin: Commit {} has been approved by `{}`\n\n<!-- @{} r={} {} -->'  # noqa
                         .format(
                             state.head_sha,
                             approver,


### PR DESCRIPTION
7 digits are no longer sufficient for rust-lang/rust. Since GitHub is going to truncate the hash automatically when rendering the post, let's just print the full 40-digit hash.

(Context: https://botbot.me/mozilla/rust-internals/2018-05-03/?msg=99660520&page=3)

r? @pietroalbini 
