### PR TITLE
`r? @ghost` when creating rollup.

### DIFF
--- a/homu/server.py
+++ b/homu/server.py
@@ -246,6 +246,7 @@ def rollup(user_gh, state, repo_label, repo_cfg, repo):
     body += '\nFailed merges:\n\n'
     for x in failures:
         body += ' - #{} ({})\n'.format(x.num, x.title)
+    body += '\nr? @ghost'
 
     try:
         rollup = repo_cfg.get('branch', {}).get('rollup', 'rollup')


### PR DESCRIPTION
Suggested by @pietroalbini, this will mute @rust-highfive when the PR is created.

(Details: https://mozilla.logbot.info/rust-infra/20180524#c14802558)