### PR TITLE
Various updates.

### DIFF
--- a/homu/main.py
+++ b/homu/main.py
@@ -22,6 +22,7 @@ import subprocess
 from .git_helper import SSH_KEY_FILE
 import shlex
 import random
+import weakref
 
 STATUS_TO_PRIORITY = {
     'success': 0,
@@ -343,7 +344,13 @@ class PullReqState:
     def start_testing(self, timeout):
         self.test_started = time.time()     # FIXME: Save in the local database
         self.set_status('pending')
-        timer = Timer(timeout, self.timed_out)
+
+        wm = weakref.WeakMethod(self.timed_out)
+        def timed_out():
+            m = wm()
+            if m:
+                m()
+        timer = Timer(timeout, timed_out)
         timer.start()
         self.timeout_timer = timer
 

--- a/homu/main.py
+++ b/homu/main.py
@@ -642,6 +642,14 @@ def parse_commands(body, username, repo_cfg, state, my_username, db, states,
         elif word in ['try', 'try-'] and realtime:
             if not _try_auth_verified():
                 continue
+            if state.status == '' and state.approved_by:
+                state.add_comment(
+                    ':no_good: '
+                    'Please do not `try` after a pull request has been `r+`ed.'
+                    ' If you need to `try`, unapprove (`r-`) it first.'
+                )
+                continue
+
             state.try_ = word == 'try'
 
             state.merge_sha = ''

--- a/homu/main.py
+++ b/homu/main.py
@@ -488,11 +488,20 @@ def parse_commands(body, username, repo_cfg, state, my_username, db, states,
                 continue
 
             # Ignore WIP PRs
-            if any(map(state.title.startswith, [
-                'WIP', 'TODO', '[WIP]', '[TODO]',
-            ])):
-                if realtime:
-                    state.add_comment(':clipboard: Looks like this PR is still in progress, ignoring approval')  # noqa
+            is_wip = False
+            for wip_kw in ['WIP', 'TODO', '[WIP]', '[TODO]', '[DO NOT MERGE]']:
+                if state.title.upper().startswith(wip_kw):
+                    if realtime:
+                        state.add_comment((
+                            ':clipboard:'
+                            ' Looks like this PR is still in progress,'
+                            ' ignoring approval.\n\n'
+                            'Hint: Remove **{}** from this PR\'s title when'
+                            ' it is ready for review.'
+                        ).format(wip_kw))
+                    is_wip = True
+                    break
+            if is_wip:
                 continue
 
             # Sometimes, GitHub sends the head SHA of a PR as 0000000


### PR DESCRIPTION
1. On merge conflict, shows what is being in conflict, and added some description how to perform a `git rebase`.
2. Disallow `@bors try` after `@bors r+` (Fix #3)
3. Treat `[DO NOT MERGE]` as the same as `[WIP]`.
4. Break an RC cycle with `weakref`.