### PR TITLE
Handle base branch changes

### DIFF
--- a/homu/main.py
+++ b/homu/main.py
@@ -1200,7 +1200,9 @@ def start_build(state, repo_cfgs, buildbot_slots, logger, db, git_cfg):
 
     lazy_debug(logger, lambda: "start_build on {!r}".format(state.get_repo()))
 
-    assert state.head_sha == state.get_repo().pull_request(state.num).head.sha
+    pr = state.get_repo().pull_request(state.num)
+    assert state.head_sha == pr.head.sha
+    assert state.base_ref == pr.base.ref
 
     repo_cfg = repo_cfgs[state.repo_label]
 

--- a/homu/server.py
+++ b/homu/server.py
@@ -467,6 +467,9 @@ def github():
                         '<!-- @{} r- -->'.format(base_ref, g.my_username)
                     )
 
+            state.title = info['pull_request']['title']
+            state.body = info['pull_request']['body']
+
             state.save()
 
         else:


### PR DESCRIPTION
The current homu codebase doesn't listen for base branch changes, so if a PR is created targeting master and then switched to target beta (like https://github.com/rust-lang/rust/pull/57670), the PR is going to be merged on master.

This PR makes three changes to homu:

* Add a check before starting a test to make sure the base branch is the same recorded by homu
* Listen for base branch changes and update the homu state
* Unapprove the PR if it was previously approved, and stop testing it if it's already testing. This prevent malicious actors from making a PR targeting beta and then switching it to target stable after the reviewer approved it.

I also added a few lines to update PR title and body when it changes, since I was changing this part of the code anyway.

r? @alexcrichton or @kennytm 
cc @Manishearth @jdm, you probably want to cherry-pick this on servo's homu